### PR TITLE
Add session-specific storage and limit reminder emails to waking hours

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -4,6 +4,9 @@ var PROPERTY_KEYS = {
   reminderInterval: 'reminderInterval',
   lastReminder: 'lastReminder'
 };
+var SESSION_INDEX_KEY = 'sessions:index';
+var SESSION_PREFIX = 'session:';
+var SESSION_ACTIVE_KEY = 'active';
 
 var DEFAULT_REMINDER_MINUTES = 120;
 var MIN_REMINDER_MINUTES = 30;
@@ -65,21 +68,30 @@ function doGet(e) {
     .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
 }
 
-function startFast(customTimestamp) {
-  return applyFastStart(customTimestamp);
+function startFast(sessionId, customTimestamp) {
+  if (arguments.length === 1) {
+    customTimestamp = sessionId;
+    sessionId = null;
+  }
+  return applyFastStart(sessionId, customTimestamp);
 }
 
-function setFastStart(customTimestamp) {
-  return applyFastStart(customTimestamp);
+function setFastStart(sessionId, customTimestamp) {
+  if (arguments.length === 1) {
+    customTimestamp = sessionId;
+    sessionId = null;
+  }
+  return applyFastStart(sessionId, customTimestamp);
 }
 
-function applyFastStart(customTimestamp) {
+function applyFastStart(sessionId, customTimestamp) {
   var props = PropertiesService.getUserProperties();
   var now = new Date().getTime();
   var startTime = resolveStartTimestamp(customTimestamp, now);
-  persistFastStart(props, startTime);
+  var resolvedSession = resolveSessionId(sessionId);
+  persistFastStart(props, resolvedSession, startTime);
   ensureReminderTrigger();
-  return getStatus();
+  return getStatus(resolvedSession);
 }
 
 function resolveStartTimestamp(customTimestamp, now) {
@@ -108,57 +120,222 @@ function resolveStartTimestamp(customTimestamp, now) {
   return parsed;
 }
 
-function persistFastStart(props, startTime) {
-  var previousStartValue = props.getProperty(PROPERTY_KEYS.fastStart);
+function resolveSessionId(sessionId) {
+  if (sessionId === undefined || sessionId === null || sessionId === '') {
+    return 'default';
+  }
+  if (typeof sessionId !== 'string') {
+    sessionId = String(sessionId);
+  }
+  var sanitized = sessionId.replace(/[^a-zA-Z0-9_-]/g, '').substring(0, 80);
+  if (!sanitized) {
+    return 'default';
+  }
+  return sanitized;
+}
+
+function buildSessionKey(sessionId, key) {
+  return SESSION_PREFIX + sessionId + ':' + key;
+}
+
+function getSessionProperty(props, sessionId, key) {
+  var propertyKey = buildSessionKey(sessionId, key);
+  var value = props.getProperty(propertyKey);
+  if (value !== null && value !== undefined) {
+    return value;
+  }
+  if (sessionId === 'default') {
+    return props.getProperty(PROPERTY_KEYS[key] ? PROPERTY_KEYS[key] : key);
+  }
+  return null;
+}
+
+function setSessionProperty(props, sessionId, key, value) {
+  props.setProperty(buildSessionKey(sessionId, key), value);
+  if (sessionId === 'default' && PROPERTY_KEYS[key]) {
+    props.setProperty(PROPERTY_KEYS[key], value);
+  }
+  recordSessionId(props, sessionId);
+}
+
+function deleteSessionProperty(props, sessionId, key) {
+  props.deleteProperty(buildSessionKey(sessionId, key));
+  if (sessionId === 'default' && PROPERTY_KEYS[key]) {
+    props.deleteProperty(PROPERTY_KEYS[key]);
+  }
+  cleanupSessionIfInactive(props, sessionId);
+}
+
+function recordSessionId(props, sessionId) {
+  if (!sessionId) {
+    return;
+  }
+  var list = listSessionIds(props);
+  if (list.indexOf(sessionId) === -1) {
+    list.push(sessionId);
+    props.setProperty(SESSION_INDEX_KEY, JSON.stringify(list));
+  }
+}
+
+function listSessionIds(props) {
+  var raw = props.getProperty(SESSION_INDEX_KEY);
+  var list = [];
+  if (raw) {
+    try {
+      var parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        list = parsed.filter(function (item) {
+          return typeof item === 'string' && item;
+        });
+      }
+    } catch (err) {
+      list = [];
+    }
+  }
+  if (list.indexOf('default') === -1) {
+    if (props.getProperty(PROPERTY_KEYS.fastStart) || props.getProperty(PROPERTY_KEYS.lastDrink) || props.getProperty(PROPERTY_KEYS.lastReminder)) {
+      list.push('default');
+    }
+  }
+  return list;
+}
+
+function removeSessionId(props, sessionId) {
+  var raw = props.getProperty(SESSION_INDEX_KEY);
+  if (!raw) {
+    return;
+  }
+  try {
+    var parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      var filtered = parsed.filter(function (item) {
+        return item !== sessionId;
+      });
+      props.setProperty(SESSION_INDEX_KEY, JSON.stringify(filtered));
+    }
+  } catch (err) {
+    props.deleteProperty(SESSION_INDEX_KEY);
+  }
+}
+
+function cleanupSessionIfInactive(props, sessionId) {
+  if (!sessionId) {
+    return;
+  }
+  var hasActiveMarker = props.getProperty(buildSessionKey(sessionId, SESSION_ACTIVE_KEY));
+  var hasFastStart = getSessionProperty(props, sessionId, PROPERTY_KEYS.fastStart);
+  var hasLastDrink = getSessionProperty(props, sessionId, PROPERTY_KEYS.lastDrink);
+  var hasLastReminder = getSessionProperty(props, sessionId, PROPERTY_KEYS.lastReminder);
+  var hasInterval = getSessionProperty(props, sessionId, PROPERTY_KEYS.reminderInterval);
+  if (!hasActiveMarker && !hasFastStart && !hasLastDrink && !hasLastReminder && !hasInterval) {
+    removeSessionId(props, sessionId);
+  }
+}
+
+function markSessionActive(props, sessionId) {
+  setSessionProperty(props, sessionId, SESSION_ACTIVE_KEY, 'true');
+}
+
+function markSessionInactive(props, sessionId) {
+  deleteSessionProperty(props, sessionId, SESSION_ACTIVE_KEY);
+}
+
+function getAggregateReminderInterval(props) {
+  var sessionIds = listSessionIds(props);
+  var minInterval = null;
+  var fastActive = false;
+  for (var i = 0; i < sessionIds.length; i++) {
+    var sessionId = sessionIds[i];
+    var startValue = getSessionProperty(props, sessionId, PROPERTY_KEYS.fastStart);
+    if (!startValue) {
+      continue;
+    }
+    fastActive = true;
+    var intervalValue = getSessionProperty(props, sessionId, PROPERTY_KEYS.reminderInterval);
+    var interval = intervalValue ? parseInt(intervalValue, 10) : DEFAULT_REMINDER_MINUTES;
+    if (!interval || interval <= 0) {
+      continue;
+    }
+    if (minInterval === null || interval < minInterval) {
+      minInterval = interval;
+    }
+  }
+  return {
+    fastActive: fastActive,
+    interval: minInterval
+  };
+}
+
+function persistFastStart(props, sessionId, startTime) {
+  var previousStartValue = getSessionProperty(props, sessionId, PROPERTY_KEYS.fastStart);
   var previousStart = previousStartValue ? parseInt(previousStartValue, 10) : null;
   var startValue = startTime.toString();
-  props.setProperty(PROPERTY_KEYS.fastStart, startValue);
-  var lastDrinkValue = props.getProperty(PROPERTY_KEYS.lastDrink);
+  setSessionProperty(props, sessionId, PROPERTY_KEYS.fastStart, startValue);
+  var lastDrinkValue = getSessionProperty(props, sessionId, PROPERTY_KEYS.lastDrink);
   var lastDrink = lastDrinkValue ? parseInt(lastDrinkValue, 10) : null;
   if (!lastDrink || lastDrink < startTime || (previousStart && lastDrink === previousStart)) {
-    props.setProperty(PROPERTY_KEYS.lastDrink, startValue);
+    setSessionProperty(props, sessionId, PROPERTY_KEYS.lastDrink, startValue);
   }
-  props.deleteProperty(PROPERTY_KEYS.lastReminder);
+  deleteSessionProperty(props, sessionId, PROPERTY_KEYS.lastReminder);
+  markSessionActive(props, sessionId);
 }
 
-function stopFast() {
+function stopFast(sessionId) {
+  if (arguments.length === 0) {
+    sessionId = null;
+  }
   var props = PropertiesService.getUserProperties();
-  props.deleteProperty(PROPERTY_KEYS.fastStart);
-  props.deleteProperty(PROPERTY_KEYS.lastDrink);
-  props.deleteProperty(PROPERTY_KEYS.lastReminder);
+  var resolvedSession = resolveSessionId(sessionId);
+  deleteSessionProperty(props, resolvedSession, PROPERTY_KEYS.fastStart);
+  deleteSessionProperty(props, resolvedSession, PROPERTY_KEYS.lastDrink);
+  deleteSessionProperty(props, resolvedSession, PROPERTY_KEYS.lastReminder);
+  markSessionInactive(props, resolvedSession);
   ensureReminderTrigger();
-  return getStatus();
+  return getStatus(resolvedSession);
 }
 
-function recordHydration() {
+function recordHydration(sessionId) {
+  if (arguments.length === 0) {
+    sessionId = null;
+  }
   var props = PropertiesService.getUserProperties();
   var now = new Date().getTime();
-  props.setProperty(PROPERTY_KEYS.lastDrink, now.toString());
-  props.deleteProperty(PROPERTY_KEYS.lastReminder);
-  return getStatus();
+  var resolvedSession = resolveSessionId(sessionId);
+  setSessionProperty(props, resolvedSession, PROPERTY_KEYS.lastDrink, now.toString());
+  deleteSessionProperty(props, resolvedSession, PROPERTY_KEYS.lastReminder);
+  return getStatus(resolvedSession);
 }
 
-function setReminderInterval(intervalMinutes) {
+function setReminderInterval(sessionId, intervalMinutes) {
+  if (arguments.length === 1) {
+    intervalMinutes = sessionId;
+    sessionId = null;
+  }
   var interval = parseInt(intervalMinutes, 10);
   if (isNaN(interval) || interval < MIN_REMINDER_MINUTES) {
     interval = DEFAULT_REMINDER_MINUTES;
   }
   var props = PropertiesService.getUserProperties();
-  props.setProperty(PROPERTY_KEYS.reminderInterval, interval.toString());
+  var resolvedSession = resolveSessionId(sessionId);
+  setSessionProperty(props, resolvedSession, PROPERTY_KEYS.reminderInterval, interval.toString());
   ensureReminderTrigger();
-  return getStatus();
+  return getStatus(resolvedSession);
 }
 
-function getStatus() {
+function getStatus(sessionId) {
+  if (arguments.length === 0) {
+    sessionId = null;
+  }
   var props = PropertiesService.getUserProperties();
+  var resolvedSession = resolveSessionId(sessionId);
   var now = new Date().getTime();
-  var startValue = props.getProperty(PROPERTY_KEYS.fastStart);
+  var startValue = getSessionProperty(props, resolvedSession, PROPERTY_KEYS.fastStart);
   var startTimestamp = startValue ? parseInt(startValue, 10) : null;
   var elapsedMinutes = startTimestamp ? Math.max(0, Math.floor((now - startTimestamp) / 60000)) : 0;
   var elapsedHours = elapsedMinutes / 60;
   var timeline = getFastingTimeline();
   var phaseDetails = getPhaseDetailsFromHours(elapsedHours, timeline);
-  var hydration = buildHydrationStatus(props, now, startTimestamp);
+  var hydration = buildHydrationStatus(props, now, startTimestamp, resolvedSession);
   var progressTarget = getProgressTargetHours(timeline);
   var progressPercent = startTimestamp ? Math.min(100, Math.round((elapsedHours / progressTarget) * 100)) : 0;
   var response = {
@@ -306,12 +483,12 @@ function getFastingTimeline() {
   ];
 }
 
-function buildHydrationStatus(props, now, startTimestamp) {
-  var lastDrinkValue = props.getProperty(PROPERTY_KEYS.lastDrink);
+function buildHydrationStatus(props, now, startTimestamp, sessionId) {
+  var lastDrinkValue = getSessionProperty(props, sessionId, PROPERTY_KEYS.lastDrink);
   var lastDrink = lastDrinkValue ? parseInt(lastDrinkValue, 10) : null;
-  var intervalValue = props.getProperty(PROPERTY_KEYS.reminderInterval);
+  var intervalValue = getSessionProperty(props, sessionId, PROPERTY_KEYS.reminderInterval);
   var interval = intervalValue ? parseInt(intervalValue, 10) : DEFAULT_REMINDER_MINUTES;
-  var lastReminderValue = props.getProperty(PROPERTY_KEYS.lastReminder);
+  var lastReminderValue = getSessionProperty(props, sessionId, PROPERTY_KEYS.lastReminder);
   var lastReminder = lastReminderValue ? parseInt(lastReminderValue, 10) : null;
   var nextReminderMinutes = null;
   if (startTimestamp && interval > 0) {
@@ -396,19 +573,19 @@ function ensureReminderTrigger() {
     return;
   }
   var props = PropertiesService.getUserProperties();
-  var intervalValue = props.getProperty(PROPERTY_KEYS.reminderInterval);
-  var interval = intervalValue ? parseInt(intervalValue, 10) : DEFAULT_REMINDER_MINUTES;
-  var fastActive = !!props.getProperty(PROPERTY_KEYS.fastStart);
+  var intervalData = getAggregateReminderInterval(props);
+  var fastActive = intervalData.fastActive;
   var triggers = ScriptApp.getProjectTriggers();
   for (var i = 0; i < triggers.length; i++) {
     if (triggers[i].getHandlerFunction() === 'sendReminder') {
       ScriptApp.deleteTrigger(triggers[i]);
     }
   }
-  if (!fastActive || !interval || interval <= 0) {
+  if (!fastActive || !intervalData.interval || intervalData.interval <= 0) {
     return;
   }
   var builder = ScriptApp.newTrigger('sendReminder').timeBased();
+  var interval = intervalData.interval;
   if (interval <= 60) {
     builder.everyMinutes(Math.max(1, interval));
   } else {
@@ -452,38 +629,56 @@ function getServiceWorkerContent() {
 
 function sendReminder() {
   var props = PropertiesService.getUserProperties();
-  var startValue = props.getProperty(PROPERTY_KEYS.fastStart);
-  if (!startValue) {
-    return 'No active fast.';
+  var sessionIds = listSessionIds(props);
+  if (!sessionIds.length) {
+    return 'No sessions registered.';
   }
-  var intervalValue = props.getProperty(PROPERTY_KEYS.reminderInterval);
-  var interval = intervalValue ? parseInt(intervalValue, 10) : DEFAULT_REMINDER_MINUTES;
-  if (!interval || interval <= 0) {
-    return 'Reminders disabled.';
-  }
-  var now = new Date().getTime();
-  var lastDrinkValue = props.getProperty(PROPERTY_KEYS.lastDrink);
-  var lastDrink = lastDrinkValue ? parseInt(lastDrinkValue, 10) : parseInt(startValue, 10);
-  var lastReminderValue = props.getProperty(PROPERTY_KEYS.lastReminder);
-  var lastReminder = lastReminderValue ? parseInt(lastReminderValue, 10) : 0;
-  var intervalMillis = interval * 60000;
-  if (now - lastDrink < intervalMillis && now - lastReminder < intervalMillis) {
-    return 'Hydration up to date.';
-  }
+  var now = new Date();
+  var nowMs = now.getTime();
+  var hour = now.getHours();
+  var wakingHours = hour >= 5 && hour < 21;
   var email = '';
   if (typeof Session !== 'undefined' && Session.getActiveUser) {
     email = Session.getActiveUser().getEmail();
   }
-  if (email) {
-    var fastingMinutes = Math.floor((now - parseInt(startValue, 10)) / 60000);
-    var emailBody = 'Time to drink water with electrolytes! You\'ve been fasting for ' +
-      formatDuration(fastingMinutes) + '. Keep going—you are doing great.';
-    MailApp.sendEmail({
-      to: email,
-      subject: 'HydraFast Hydration Reminder',
-      body: emailBody
-    });
+  var sentCount = 0;
+  for (var i = 0; i < sessionIds.length; i++) {
+    var sessionId = sessionIds[i];
+    var startValue = getSessionProperty(props, sessionId, PROPERTY_KEYS.fastStart);
+    if (!startValue) {
+      continue;
+    }
+    var intervalValue = getSessionProperty(props, sessionId, PROPERTY_KEYS.reminderInterval);
+    var interval = intervalValue ? parseInt(intervalValue, 10) : DEFAULT_REMINDER_MINUTES;
+    if (!interval || interval <= 0) {
+      continue;
+    }
+    var lastDrinkValue = getSessionProperty(props, sessionId, PROPERTY_KEYS.lastDrink);
+    var lastDrink = lastDrinkValue ? parseInt(lastDrinkValue, 10) : parseInt(startValue, 10);
+    var lastReminderValue = getSessionProperty(props, sessionId, PROPERTY_KEYS.lastReminder);
+    var lastReminder = lastReminderValue ? parseInt(lastReminderValue, 10) : 0;
+    var intervalMillis = interval * 60000;
+    if (nowMs - lastDrink < intervalMillis && nowMs - lastReminder < intervalMillis) {
+      continue;
+    }
+    if (!wakingHours) {
+      continue;
+    }
+    if (email) {
+      var fastingMinutes = Math.floor((nowMs - parseInt(startValue, 10)) / 60000);
+      var emailBody = 'Time to drink water with electrolytes! You\'ve been fasting for ' +
+        formatDuration(fastingMinutes) + '. Keep going—you are doing great.';
+      MailApp.sendEmail({
+        to: email,
+        subject: 'HydraFast Hydration Reminder',
+        body: emailBody
+      });
+    }
+    setSessionProperty(props, sessionId, PROPERTY_KEYS.lastReminder, nowMs.toString());
+    sentCount++;
   }
-  props.setProperty(PROPERTY_KEYS.lastReminder, now.toString());
-  return 'Reminder sent.';
+  if (sentCount === 0) {
+    return wakingHours ? 'Hydration up to date.' : 'Outside waking hours.';
+  }
+  return 'Reminders sent: ' + sentCount;
 }

--- a/index.html
+++ b/index.html
@@ -1152,9 +1152,11 @@
     let isLoading = false;
     let refreshTimer = null;
     let circleState = null;
+    let deviceSessionId = null;
 
     const circleResponseTimers = {};
     const circleConnectionTimers = {};
+    const LOCAL_SESSION_KEY = 'hydrafast:sessionId:v1';
     const LOCAL_PROFILE_KEY = 'hydrafast:deviceProfile:v2';
     const LOCAL_CIRCLE_KEY = 'hydrafast:circle:v1';
     const DEFAULT_REMINDER_MINUTES = 120;
@@ -1461,7 +1463,7 @@
           showToast('Unable to refresh status. Please try again.');
           console.error(err);
         })
-        .getStatus();
+        .getStatus(ensureDeviceSession());
     }
 
     function handleStart() {
@@ -1499,7 +1501,7 @@
           console.error(err);
           setButtonsDisabled(false);
         })
-        .startFast(timestamp);
+        .startFast(ensureDeviceSession(), timestamp);
     }
 
     function handleStop() {
@@ -1523,7 +1525,7 @@
           console.error(err);
           setButtonsDisabled(false);
         })
-        .stopFast();
+        .stopFast(ensureDeviceSession());
     }
 
     function handleDrink() {
@@ -1547,7 +1549,7 @@
           console.error(err);
           setButtonsDisabled(false);
         })
-        .recordHydration();
+        .recordHydration(ensureDeviceSession());
     }
 
     function handleReminderChange(value) {
@@ -1568,7 +1570,7 @@
           showToast('Unable to update reminders.');
           console.error(err);
         })
-        .setReminderInterval(value);
+        .setReminderInterval(ensureDeviceSession(), value);
     }
 
     function handleSaveStartTime() {
@@ -1606,7 +1608,7 @@
           console.error(err);
           setButtonsDisabled(false);
         })
-        .setFastStart(timestamp);
+        .setFastStart(ensureDeviceSession(), timestamp);
     }
 
     function renderStatus(status) {
@@ -3072,6 +3074,40 @@
           }
         });
       }
+    }
+
+    function ensureDeviceSession() {
+      if (deviceSessionId) {
+        return deviceSessionId;
+      }
+      let stored = null;
+      if (supportsLocalStorage()) {
+        try {
+          stored = localStorage.getItem(LOCAL_SESSION_KEY);
+        } catch (err) {
+          stored = null;
+        }
+      }
+      if (!stored) {
+        stored = generateSessionId();
+        if (supportsLocalStorage()) {
+          try {
+            localStorage.setItem(LOCAL_SESSION_KEY, stored);
+          } catch (err) {
+            // Ignore storage write failures.
+          }
+        }
+      }
+      deviceSessionId = stored;
+      return deviceSessionId;
+    }
+
+    function generateSessionId() {
+      if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+        return crypto.randomUUID();
+      }
+      const random = Math.random().toString(16).slice(2);
+      return 'sess-' + Date.now().toString(36) + '-' + random;
     }
 
     function saveLocalProfile(profile) {


### PR DESCRIPTION
## Summary
- scope hydration and fasting data by session so each device maintains its own state while keeping reminder triggers in sync
- generate and persist a per-device session identifier in the client and send it with each Apps Script action
- restrict hydration reminder emails to the 5am-9pm window and skip sends outside of waking hours

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e3d7958fc4832e8af4e60e1e028eee